### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -39,7 +39,11 @@ class PhotoshopEngine(tank.platform.Engine):
         self._panel_generator = tk_photoshop.PanelGenerator(self)
         self._panel_generator.populate_panel()
 
-        self.log_user_attribute_metric("Photoshop version", str(app.version))
+        try:
+            self.log_user_attribute_metric("Photoshop version", str(app.version))
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
     def destroy_engine(self):
         self.log_debug("%s: Destroying...", self)

--- a/engine.py
+++ b/engine.py
@@ -18,6 +18,7 @@ import logging
 import tank
 
 from photoshop.flexbase import FlexRequest
+from photoshop import app
 
 
 ###############################################################################################
@@ -37,6 +38,8 @@ class PhotoshopEngine(tank.platform.Engine):
         self._initialize_dark_look_and_feel()
         self._panel_generator = tk_photoshop.PanelGenerator(self)
         self._panel_generator.populate_panel()
+
+        self.log_user_attribute_metric("Photoshop version", str(app.version))
 
     def destroy_engine(self):
         self.log_debug("%s: Destroying...", self)

--- a/info.yml
+++ b/info.yml
@@ -28,4 +28,3 @@ description: "Shotgun Integration in Photoshop"
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
 
-# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -28,3 +28,4 @@ description: "Shotgun Integration in Photoshop"
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
 
+# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.